### PR TITLE
fix 'make install' not working problem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ scripts/fuzz-napsat.sh
 scripts/run-napsat.sh
 scripts/runcnfuzz
 executables/*
+
+.idea

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ debug: $(BUILD_DIR)/$(TARGET_LIB)
 debug: $(BUILD_DIR)/$(EXEC)
 
 .PHONY: install
+install:
 	sudo apt-get install liblzma-dev
 
 install-test:


### PR DESCRIPTION
The library `liblzma-dev` should be installed after running `make install`, but this is not the case currently.
After executing `make install`, the following message is displayed:
_make: Nothing to be done for 'install'._

This pull request addresses and fixes this issue.